### PR TITLE
✨ feat(HAT-244): 사용자 권한 페이지 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,9 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { RecoilRoot } from "recoil";
 
 import RealTimePage from "components/pages/AirQuality/RealTimePage";
+import AuthRoutes from "components/pages/Auth/AuthRoutes";
 import LoginPage from "components/pages/Auth/Login/LoginPage";
+import EditProfile from "components/pages/Auth/Profile/EditProfile";
 import MyPage from "components/pages/Auth/Profile/MyPage";
 import RegisterPage from "components/pages/Auth/Register/RegisterPage";
 import CommunityPage from "components/pages/Community/CommunityPage";
@@ -15,13 +17,15 @@ const App: React.FC = () => {
     <RecoilRoot>
       <Router>
         <Routes>
-          <Route path="/login" element={<LoginPage />} />
-
           <Route path="/" element={<MainPage />} />
+          <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
-          <Route path="/community" element={<CommunityPage />} />
           <Route path="/airquality" element={<RealTimePage />} />
-          <Route path="/my-page" element={<MyPage />} />
+          <Route element={<AuthRoutes />}>
+            <Route path="/community" element={<CommunityPage />} />
+            <Route path="/my-page" element={<MyPage />} />
+            <Route path="/edit" element={<EditProfile />} />
+          </Route>
         </Routes>
       </Router>
     </RecoilRoot>

--- a/src/components/pages/Auth/AuthRoutes.tsx
+++ b/src/components/pages/Auth/AuthRoutes.tsx
@@ -6,8 +6,14 @@ import LoginPage from "components/pages/Auth/Login/LoginPage";
 import { memberState } from "stores";
 
 const AuthRoutes = () => {
-  const member = useRecoilValue(memberState);
-  return member !== null ? <Outlet /> : <LoginPage />;
+  const isAuthenticated = useRecoilValue(memberState) !== null;
+
+  return (
+    <>
+      {isAuthenticated && <Outlet />}
+      {!isAuthenticated && <LoginPage />}
+    </>
+  );
 };
 
 export default AuthRoutes;

--- a/src/components/pages/Auth/AuthRoutes.tsx
+++ b/src/components/pages/Auth/AuthRoutes.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from "react-router-dom";
+
+import { useRecoilValue } from "recoil";
+
+import LoginPage from "components/pages/Auth/Login/LoginPage";
+import { memberState } from "stores";
+
+const AuthRoutes = () => {
+  const member = useRecoilValue(memberState);
+  return member !== null ? <Outlet /> : <LoginPage />;
+};
+
+export default AuthRoutes;

--- a/src/components/pages/Auth/Profile/EditProfile.tsx
+++ b/src/components/pages/Auth/Profile/EditProfile.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function EditProfile() {
+  return <div>EditProfile</div>;
+}

--- a/src/components/pages/Auth/Profile/MyPage.tsx
+++ b/src/components/pages/Auth/Profile/MyPage.tsx
@@ -94,9 +94,15 @@ const Profile: React.FC = () => {
     setDropdownOpen(!dropdownOpen);
   };
 
-  const handleLogout = () => {
-    // perform logout logic
-    console.log("Logout clicked");
+  const handleLogout = async () => {
+    try {
+      await axios.post("http://localhost:11000/api/v1/auth/logout");
+      setMember(null);
+      localStorage.removeItem("recoil-persist");
+      navigate("/");
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   const handleEditProfile = () => {

--- a/src/components/pages/Auth/Profile/MyPage.tsx
+++ b/src/components/pages/Auth/Profile/MyPage.tsx
@@ -1,4 +1,6 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useState, useRef } from "react";
+import { BiDotsVerticalRounded } from "react-icons/bi";
+import { useNavigate } from "react-router-dom";
 
 import axios from "axios";
 import { useRecoilState } from "recoil";
@@ -58,14 +60,71 @@ const GridItemSubtitle = styled.p`
   ${tw`text-gray-500`}
 `;
 
+const Icon = styled(BiDotsVerticalRounded)`
+  font-size: 32px;
+`;
+
+const EditButton = styled.button`
+  position: absolute;
+  right: 16px;
+  margin: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Dropdown = styled.div`
+  ${tw`absolute right-0 mt-2 py-2 w-48 bg-white rounded-lg shadow-xl z-10`}
+`;
+
+const DropdownItem = styled.button`
+  ${tw`w-full text-left px-3 py-2 text-gray-700 hover:bg-gray-100 hover:text-gray-900`}
+  &:focus {
+    ${tw`bg-gray-100`}
+  }
+`;
+
 const Profile: React.FC = () => {
-  const [profileName, setProfileName] = useState("");
   const [member, setMember] = useRecoilState(memberState);
-  //   console.log(member);
+  const navigate = useNavigate();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const handleEditButtonClick = () => {
+    setDropdownOpen(!dropdownOpen);
+  };
+
+  const handleLogout = () => {
+    // perform logout logic
+    console.log("Logout clicked");
+  };
+
+  const handleEditProfile = () => {
+    // navigate to edit profile page
+    console.log("Edit profile clicked");
+    navigate(`/edit`);
+  };
 
   const handleNotificationClick = () => {
     console.log("Notification button clicked");
   };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [dropdownRef]);
+
   return (
     <ProfileContainer>
       <MainPageHeader
@@ -74,7 +133,20 @@ const Profile: React.FC = () => {
         onNotificationClick={handleNotificationClick}
       />
       <Content>
-        <ProfileImage src="/images/very-good-hat.svg" alt="Profile image" />
+        <div>
+          <EditButton onClick={handleEditButtonClick}>
+            <Icon />
+          </EditButton>
+          {dropdownOpen && (
+            <Dropdown ref={dropdownRef}>
+              <DropdownItem onClick={handleEditProfile}>
+                Edit Profile
+              </DropdownItem>
+              <DropdownItem onClick={handleLogout}>Logout</DropdownItem>
+            </Dropdown>
+          )}
+          <ProfileImage src="/images/very-good-hat.svg" alt="Profile image" />
+        </div>
         <ProfileName>{member && `${member.nickname}`}</ProfileName>
         <GridContainer>
           <GridItem>
@@ -82,20 +154,6 @@ const Profile: React.FC = () => {
             <GridItemOverlay>
               <GridItemTitle>Post1</GridItemTitle>
               <GridItemSubtitle>April 1, 2023</GridItemSubtitle>
-            </GridItemOverlay>
-          </GridItem>
-          <GridItem>
-            <GridItemImage src="/images/sample2.jpeg" alt="Sample 2" />
-            <GridItemOverlay>
-              <GridItemTitle>Post 2</GridItemTitle>
-              <GridItemSubtitle>April 2, 2023</GridItemSubtitle>
-            </GridItemOverlay>
-          </GridItem>
-          <GridItem>
-            <GridItemImage src="/images/sample3.jpeg" alt="Sample 3" />
-            <GridItemOverlay>
-              <GridItemTitle>Post 3</GridItemTitle>
-              <GridItemSubtitle>April 3, 2023</GridItemSubtitle>
             </GridItemOverlay>
           </GridItem>
         </GridContainer>

--- a/src/components/pages/Auth/Register/RegisterPage.tsx
+++ b/src/components/pages/Auth/Register/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import styled from "styled-components";
 import tw from "twin.macro";
@@ -36,6 +36,7 @@ const RegisterPage: React.FC = () => {
   const [loginPasswordCheck, setLoginPasswordCheck] = useState("");
   const [email, setEmail] = useState("");
   const [nickname, setNickname] = useState("");
+  const navigate = useNavigate();
 
   const handleSignUpSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -61,6 +62,7 @@ const RegisterPage: React.FC = () => {
       alert("회원가입에 실패하였습니다. 입력 정보를 확인해주세요.");
     } else {
       alert("회원가입이 완료되었습니다.");
+      navigate("/login");
     }
   };
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -492,12 +492,20 @@ video {
   right: 0px;
 }
 
+.z-10 {
+  z-index: 10;
+}
+
 .mb-4 {
   margin-bottom: 1rem;
 }
 
 .mr-2 {
   margin-right: 0.5rem;
+}
+
+.mt-2 {
+  margin-top: 0.5rem;
 }
 
 .mt-4 {
@@ -542,6 +550,10 @@ video {
 
 .w-28 {
   width: 7rem;
+}
+
+.w-48 {
+  width: 12rem;
 }
 
 .w-60 {
@@ -650,6 +662,11 @@ video {
   padding-right: 0.5rem;
 }
 
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
 .px-6 {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
@@ -668,6 +685,10 @@ video {
 .py-4 {
   padding-top: 1rem;
   padding-bottom: 1rem;
+}
+
+.text-left {
+  text-align: left;
 }
 
 .text-2xl {
@@ -698,6 +719,11 @@ video {
   color: rgb(107 114 128 / var(--tw-text-opacity));
 }
 
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity));
+}
+
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
@@ -710,6 +736,12 @@ video {
 .shadow-md {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -743,6 +775,16 @@ video {
 .hover\:bg-blue-600:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(37 99 235 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-gray-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+}
+
+.hover\:text-gray-900:hover {
+  --tw-text-opacity: 1;
+  color: rgb(17 24 39 / var(--tw-text-opacity));
 }
 
 .hover\:opacity-75:hover {


### PR DESCRIPTION
## Motivation:

- 권한에 따른 페이지 처리

## Modifications:

- 사용자는 비로그인 상태에서 하단의 프로필 버튼, 피드, 글쓰기 버튼을 클릭하면 로그인 페이지로 이동시켜서 로그인을 유도한다.
- 로그인이 된 사용자는 요청 페이지를 출력한다.

## Result:

- 아래의 이미지를 참조

### 비로그인 상태에서 하단바의 프로필 이미지를 클릭하면 로그인 페이지를 출력

![image](https://user-images.githubusercontent.com/117193889/232293967-cc81e813-b12c-40f2-9bf4-32364bb0acf7.png)

### 로그인 후 결과
![image](https://user-images.githubusercontent.com/117193889/232294450-23ed6172-f72c-49c3-befe-8efe4ec1c271.png)
------

## [BE] 로그아웃 기능 추가에 따른 테스트 동작 확인
🔗 https://github.com/Hows-the-Air-Today/HAT-backend-spring-boot/pull/52

### 로그인 상태
<img width="612" alt="image" src="https://user-images.githubusercontent.com/117193889/232440804-3cb8f558-b459-4605-890c-d3190b4a2f30.png">

### 로그아웃 상태
- 로그아웃 버튼을 클릭시 다시 로그인이 필요함. 
(로그아웃 -> 메인페이지 -> 로그인)
<img width="612" alt="image" src="https://user-images.githubusercontent.com/117193889/232441085-863caf9b-17f4-4040-a87e-675b01131251.png">



