### PR TITLE
✨ feat(HAT-273): 회원 탈퇴 폼 생성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import ChangePasswordPage from "components/pages/Auth/Profile/ChangePasswordPage
 import EditNicknamePage from "components/pages/Auth/Profile/EditNicknamePage";
 import EditProfile from "components/pages/Auth/Profile/EditProfile";
 import MyPage from "components/pages/Auth/Profile/MyPage";
+import WithdrawalPage from "components/pages/Auth/Profile/WithdrawalPage";
 import RegisterPage from "components/pages/Auth/Register/RegisterPage";
 import CommunityPage from "components/pages/Community/CommunityPage";
 import MainPage from "components/pages/Main/MainPage";
@@ -29,6 +30,7 @@ const App: React.FC = () => {
             <Route path="/edit" element={<EditProfile />} />
             <Route path="/edit-nickname" element={<EditNicknamePage />} />
             <Route path="/change-password" element={<ChangePasswordPage />} />
+            <Route path="//withdrawal-check" element={<WithdrawalPage />} />
           </Route>
         </Routes>
       </Router>

--- a/src/components/pages/Auth/Profile/EditProfile.tsx
+++ b/src/components/pages/Auth/Profile/EditProfile.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef } from "react";
 import { BiEditAlt } from "react-icons/bi";
+import { RiEmotionSadLine } from "react-icons/ri";
 import { useNavigate } from "react-router-dom";
 
 import { useRecoilState } from "recoil";
@@ -61,10 +62,28 @@ const InfoInputContainer = styled.div`
   }
 `;
 
-const EditableNickname = styled.p`
+const WithdrawalContainer = styled.div`
+  ${tw`border-b-2 border-gray-300 pb-2 my-2 flex items-center justify-between`}
+  width: 100%;
+  & span {
+    ${tw`font-bold text-black mr-2`}
+  }
+  & p {
+    ${tw`text-gray-500 text-right`}
+  }
+`;
+
+const EditableInfo = styled.p`
   ${tw`text-gray-500 text-right inline-flex items-center`}
   &:hover {
     ${tw`text-blue-500`}
+  }
+`;
+
+const WithdrawalButton = styled.p`
+  ${tw`text-right inline-flex items-center`}
+  &:hover {
+    ${tw`text-red-500`}
   }
 `;
 
@@ -84,6 +103,11 @@ const EditMyProfile: React.FC = () => {
   const handleEditPasswordClick = () => {
     console.log("Edit nickname clicked");
     navigate(`/change-password`);
+  };
+
+  const handleWithdrawalClick = () => {
+    console.log("Click Withdrawal");
+    navigate(`/withdrawal-check`);
   };
 
   return (
@@ -107,10 +131,10 @@ const EditMyProfile: React.FC = () => {
         </ReadOnlyContainer>
         <InfoInputContainer>
           <span>비밀번호:</span>
-          <EditableNickname onClick={handleEditPasswordClick}>
+          <EditableInfo onClick={handleEditPasswordClick}>
             비밀번호 변경하기
             <BiEditAlt style={{ marginLeft: "8px" }} />
-          </EditableNickname>
+          </EditableInfo>
         </InfoInputContainer>
         <ReadOnlyContainer>
           <span>이메일:</span>
@@ -118,11 +142,17 @@ const EditMyProfile: React.FC = () => {
         </ReadOnlyContainer>
         <InfoInputContainer>
           <span>닉네임:</span>
-          <EditableNickname onClick={handleEditNicknameClick}>
+          <EditableInfo onClick={handleEditNicknameClick}>
             {member && `${member.nickname}`}
             <BiEditAlt style={{ marginLeft: "8px" }} />
-          </EditableNickname>
+          </EditableInfo>
         </InfoInputContainer>
+        <WithdrawalContainer>
+          <span>서비스 탈퇴</span>
+          <WithdrawalButton onClick={handleWithdrawalClick}>
+            <RiEmotionSadLine style={{ marginLeft: "8px" }} />
+          </WithdrawalButton>
+        </WithdrawalContainer>
       </EditCard>
       <BottomMenuBar />
     </EditProfileContainer>

--- a/src/components/pages/Auth/Profile/WithdrawalPage.tsx
+++ b/src/components/pages/Auth/Profile/WithdrawalPage.tsx
@@ -1,0 +1,155 @@
+import React, { useState } from "react";
+import { IoIosArrowBack } from "react-icons/io";
+import { Link, useNavigate } from "react-router-dom";
+
+import { useRecoilState, useSetRecoilState } from "recoil";
+import styled from "styled-components";
+import tw from "twin.macro";
+
+import { memberState } from "stores/memberState";
+
+import BottomMenuBar from "../../../UI/organisms/Navigation/BottomMenuBar";
+
+const WithdrawalContainer = styled.div`
+  ${tw`flex flex-col justify-center items-center h-screen bg-gray-100`}
+`;
+
+const WithdrawalCard = styled.div`
+  ${tw`flex flex-col justify-center items-center bg-white p-8 rounded-lg shadow-md`}
+  & > h1 {
+    ${tw`font-bold text-center text-lg mb-4`}
+  }
+  width: 80%;
+  display: flex;
+  align-items: center;
+`;
+
+const WithdrawalForm = styled.form`
+  ${tw`flex flex-col w-full`}
+`;
+
+const TitleContainer = styled.div`
+  ${tw`pb-2 my-2 flex items-center justify-between`}
+  width: 100%;
+  & span {
+    ${tw`font-bold text-black mr-2`}
+  }
+  & p {
+    ${tw`font-bold text-center flex-1 `}
+  }
+`;
+
+const CheckContainer = styled.div`
+  ${tw`pb-2 my-2 flex items-center justify-center`}
+  width: 100%;
+  display: flex;
+  align-items: center;
+`;
+
+const WithdrawalCheckbox = styled.input`
+  ${tw`w-4 h-4 mr-2 outline-none`}
+`;
+
+const WithdrawalButton = styled.button`
+  ${tw`w-full mt-4 py-2 rounded-md text-white bg-blue-500 hover:bg-blue-600 transition duration-300`}
+`;
+
+const TextCardContainer = styled.div`
+  ${tw`max-w-sm rounded-lg overflow-hidden shadow-md bg-white`}
+  width: 100%;
+`;
+
+const TextCardContent = styled.div`
+  ${tw`p-4`}
+`;
+
+const TextCardTitle = styled.h2`
+  ${tw`text-lg font-bold mb-2 text-center text-red-500`}
+`;
+
+const TextCardDescription = styled.p`
+  ${tw`text-gray-700`}
+  display: flex;
+  flex-direction: column;
+  line-height: 1.5;
+  margin: 16px;
+`;
+
+const WithdrawalMember: React.FC = () => {
+  const [member, setMember] = useRecoilState(memberState);
+  const [isWithdrawalConfirmed, setIsWithdrawalConfirmed] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
+
+  const navigate = useNavigate();
+
+  const { memberId } = member;
+  const { accessToken } = member;
+
+  const handleWithdrawalSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!isChecked) {
+      alert("서비스 탈퇴를 위해 동의해주세요.");
+      return;
+    }
+
+    const response = await fetch(
+      `http://localhost:11000/api/v1/auth/${memberId}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ memberId }),
+      }
+    );
+    if (!response.ok) {
+      alert("서비스 탈퇴에 실패했습니다. 다시 시도해주세요.");
+    } else {
+      alert("서비스 탈퇴가 완료되었습니다.");
+      setMember(null);
+      navigate("/");
+    }
+  };
+  return (
+    <WithdrawalContainer>
+      <WithdrawalCard>
+        <TitleContainer>
+          <span>
+            <Link to="/edit">
+              <IoIosArrowBack />
+            </Link>
+          </span>
+          <p>
+            <h1>서비스 탈퇴</h1>
+          </p>
+        </TitleContainer>
+        <TextCardContainer>
+          <TextCardContent>
+            <TextCardTitle>주의 사항</TextCardTitle>
+            <TextCardDescription>
+              <span>✅ 회원님께서 가입하신 모든 정보는 모두 삭제 됩니다.</span>
+              <span>✅ 정말로 탈퇴를 원하시나요? 🥹 </span>
+            </TextCardDescription>
+          </TextCardContent>
+        </TextCardContainer>
+        <WithdrawalForm onSubmit={handleWithdrawalSubmit}>
+          <CheckContainer>
+            <span>동의하기</span>
+            <WithdrawalCheckbox
+              type="checkbox"
+              id="withdrawal-checkbox"
+              onChange={() => setIsChecked(!isChecked)}
+              checked={isChecked}
+            />
+          </CheckContainer>
+          <WithdrawalButton type="submit">탈퇴하기</WithdrawalButton>
+        </WithdrawalForm>
+      </WithdrawalCard>
+      <BottomMenuBar />
+    </WithdrawalContainer>
+  );
+};
+
+export default WithdrawalMember;


### PR DESCRIPTION
## Motivation:

- 회원 탈퇴 기능 구현

## Modifications:

- 로그인된 사용자에 한해 사용자가 원하는 경우, 회원 정보를 탈퇴할 수 있다.

## Result:

- 동의하기 체크박스를 체크해야 탈퇴 가능.

### 회원 정보 수정 페이지
![mobile (6)](https://user-images.githubusercontent.com/117193889/233303318-d0c8182a-0431-4996-9bc2-e1ea6a56f1cc.png)

### 서비스 탈퇴 아이콘 클릭
![mobile (7)](https://user-images.githubusercontent.com/117193889/233303501-a0928860-415f-4eb3-829c-3b17cab1684f.png)

### 동의하기 체크박스 비활성 상태에서 탈퇴하기 버튼 클릭
<img width="612" alt="image" src="https://user-images.githubusercontent.com/117193889/233303710-da53e540-b038-40e0-8233-8bbcb936b27f.png">

### 동의하기 체크박스 활성 상태에서 탈퇴하기 버튼 클릭
<img width="612" alt="image" src="https://user-images.githubusercontent.com/117193889/233303857-7a2efb1d-45fe-40e9-8da8-3129a82dbb1c.png">

- 탈퇴 완료 후 로그아웃되면서 메인 페이지로 리다이렉트

### 재로그인 불가
<img width="612" alt="image" src="https://user-images.githubusercontent.com/117193889/233304068-0d9925ea-7850-4dcb-af5c-4aabc99af53a.png">

