### PR TITLE
👷 ci: package.json 빌드 스크립트 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "watch:css": "postcss src/styles/tailwind.css -o src/styles/styles.css",
     "start": "npm run watch:css & react-scripts start",
     "build": "GENERATE_SOURCEMAP=false npm run build:css & react-scripts build",
+    "build:ci": "CI=false GENERATE_SOURCEMAP=false npm run build:css & react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## Motivation:

- 프로젝트 빌드 시 `warning` 로그를 `error`로 취급해서 빌드 실패

```bash
Treating warnings as errors because process.env.CI = true.
Most CI servers set it automatically.

Failed to compile.
```

## Modifications:

- 빌드 스크립트에 `CI=false` 옵션 추가

```json
{
  ...
  "scripts": {
    ...
    "build": "GENERATE_SOURCEMAP=false npm run build:css & react-scripts build",
    "build:ci": "CI=false GENERATE_SOURCEMAP=false npm run build:css & react-scripts build",
    ...
  },
...
}
```

## Result:

- 젠킨스 빌드 확인 필요