### PR TITLE
🐛 fix(HAT-361): 게시글 작성 페이지 수정

### DIFF
--- a/src/components/pages/CommunityCreatPage/index.tsx
+++ b/src/components/pages/CommunityCreatPage/index.tsx
@@ -38,6 +38,7 @@ const CommunityCreatPage: React.FC = () => {
   const { memberId } = member;
   const { memberProfileImage } = member;
 
+  const [isUploading, setIsUploading] = useState(false);
   const [boxIndex, setBoxIndex] = useState<number>();
   const [textFieldData, setTextFieldData] = useState({
     content: locationState?.data?.content ? locationState?.data?.content : "",
@@ -102,7 +103,9 @@ const CommunityCreatPage: React.FC = () => {
   const handleDataChange = (type) => (e) => {
     setTextFieldData({ ...textFieldData, [type]: e.target.value });
   };
-  const onSubmitPosts = () => {
+  const onSubmitPosts = (e) => {
+    e.preventDefault();
+
     const formData = new FormData();
 
     if (
@@ -134,9 +137,15 @@ const CommunityCreatPage: React.FC = () => {
 
     formData.append("saveRequestDto", JSON.stringify(body));
 
+    if (isUploading) {
+      alert("게시글이 업로드 중이에요!");
+      return;
+    }
+
+    setIsUploading(true);
     postCreateAndUpdate(locationState, formData, accessToken)
       .then((res) => {
-        console.log(res);
+        setIsUploading(false);
 
         navigate(-1);
         alert(
@@ -144,6 +153,8 @@ const CommunityCreatPage: React.FC = () => {
         );
       })
       .catch((err) => {
+        setIsUploading(false);
+
         console.log(err);
       });
   };
@@ -202,7 +213,9 @@ const CommunityCreatPage: React.FC = () => {
           <CommonButton
             variant="outlined"
             text={locationState?.type === "수정" ? "수정" : "등록"}
-            onClick={onSubmitPosts}
+            onClick={(e) => {
+              onSubmitPosts(e);
+            }}
           />
         </CommunityFooter>
       </RootBox>

--- a/src/interface/ButtonProps.ts
+++ b/src/interface/ButtonProps.ts
@@ -6,7 +6,7 @@ export interface BackArrowProps {
 }
 
 export interface CommonButtonProps {
-  onClick: () => void;
+  onClick: (e) => void;
   text: string;
 
   size?: "small" | "medium" | "large";


### PR DESCRIPTION
## Motivation:

- 게시글 작성 페이지 수정 

## Modifications:

- slack 이슈사항 2번
  - `게시글 작성시, 여러번 클릭하면 클릭한 수 만큼 같은 게시물이 등록되어 버림.`
   문제의 원인은 여러가지가 있을수있습니다. 서버에서 이미지를 받고 `path`를 리턴 받은 이후 데이터베이스에 저장하게되고, 또한 로직을 보셨을지 모르지만 return을 받는것도모자라 `postImages`를 순회합니다. 이 부분은 사실상 현재상황에서 고쳐야하는 부분이 맞지만 저번 PR에도 날려을때도 나중에 이미지 가 여러개일경우를  생각하여 고대로 냅두었다고 말을 했었고, 이로 인하여 조금 느린부분이 없지 않아 있을것이라고 생각이들어요.  따로 이슈사항이라하면 파일크기가  600~700KB정도가되면  서버가 많이 느려지는것같습니다. 지금 현재는 기능을 막았지. 이게 꼭 좋다고 말씀드리기엔 힘들것같네요.  아니면 파일크기제한을 걸던지 .. 해야할것같네요 . 
- 만약에 이미지여러개를 첨부하며 게시글 생성시 이미지의 크기들은 엄청나게커질수도있을것같습니다. 이로 인하여 문제의 부분은 더커질수있다고생각이들어요.  여러가지 대안을 생각해보았습니다. 
- 프론트에서 처리한다. 
   - 하지만 ? 프론트에서 처리한다면 우리 취지에 엇나간다. 
- 고가용성 Lamda 서비스를 추가한다
- 현재 MultiPartFile을 받고있지만 , base64 로 받는다. `byte[]` 타입을 받아 디코딩하여 저장하는형태로한다. 
   -  솔직히 이게 맞지않나 싶음 . 근데 난 모르겠음 



근데 네트워크 문제도있나? 그렇게 느리게가진않는데.. 흠 

 **현재 지금은 수정사항 긴급히 수정해야하기때문에  했습니다.**  
## Result:
오늘 회의참석못한거 미안해요 시골을 긴급하게 내려가야하는상황이와서 어쩔수없이 참석못하게되었어요. 짤막하게나마 주형이한테 회의 얘기 들었습니다. 

주형이와 잘 얘기해서 준비할게요 

-