### PR TITLE
🚑️ fix(HAT-382): 대기질 주간예보 서비스 로직 수정

### DIFF
--- a/src/services/pmForecastService.ts
+++ b/src/services/pmForecastService.ts
@@ -116,7 +116,7 @@ const mapRegion = (region1depthName, region2depthName) => {
     if (westRegions.includes(cityRegion)) return "영서";
   }
 
-  return cityRegion;
+  return region1depthName;
 };
 
 const getRegionName = (address) => {


### PR DESCRIPTION
## Motivation:

- 지역명을 가공하는 비즈니스 로직 중 특정 지역에서 지역명이 아닌 `Null` 값을 반환하는 문제

> `서울시 서초구 반포` 기준

![image](https://user-images.githubusercontent.com/70932170/235425070-f3734e21-a39d-4932-b764-95165579e1f1.png)

![image](https://user-images.githubusercontent.com/70932170/235425082-44fd3623-5ef6-4510-924f-af228440e797.png)

## Modifications:

- 대기질 주간예보 OpenAPI를 통해 받아오는 지역명 중 `시`, `도`로 구분되는 지역이 아닌 지역들이 존재
-  아래 `JSON` 데이터는 OpenAPI 응답의 일부
```json
{
  "informGrade": "서울 : 보통,제주 : 보통,전남 : 보통,전북 : 나쁨,광주 : 보통,경남 : 보통,경북 : 보통,울산 : 보통,대구 : 보통,부산 : 보통,충남 : 보통,충북 : 나쁨,세종 : 보통,대전 : 보통,영동 : 보통,영서 : 보통,경기남부 : 보통,경기북부 : 보통,인천 : 보통"
}
```

-  위와 같이 `경기 북부`, `경기 남부`, `영동`, `영서` 지역으로 응답하는 정보를 아래와 같이 행정 구역으로 분할하여 지역명을 가공하는 서비스 로직을 작성했음

```
- 경기 북부
    - 고양시, 구리시, 남양주시, 동두천시, 양주시, 의정부시, 파주시, 포천시
    - 가평군, 연천군
- 경기 남부
    - 과천시, 광명시, 광주시, 군포시, 김포시, 부천시, 성남시, 수원시, 시흥시, 안산시, 안성시, 안양시, 여주시, 오산시, 용인시, 의왕시, 이천시, 평택시, 하남시, 화성시
    - 양평군
- 영동
    - 강릉시, 동해시, 삼척시, 속초시, 태백시
    - 고성군, 양양군
- 영서
    - 원주시, 춘천시
    - 양구군, 영월군, 인제군, 정선군, 철원군, 평창군, 홍천군, 화천군, 횡성군
```

- 아래는 서비스 로직 중 지역명을 처리하는 함수

```ts
const mapRegion = (region1depthName, region2depthName) => {
  const cityRegion = region2depthName.split(" ")[0];

  console.log("cityRegion", cityRegion);

  if (region1depthName === "경기") {
    const northRegions = [
      "고양시",
      "구리시",
      "남양주시",
      "동두천시",
      "양주시",
      "의정부시",
      "파주시",
      "포천시",
      "가평군",
      "연천군",
    ];
    const southRegions = [
      "과천시",
      "광명시",
      "광주시",
      "군포시",
      "김포시",
      "부천시",
      "성남시",
      "수원시",
      "시흥시",
      "안산시",
      "안성시",
      "안양시",
      "여주시",
      "오산시",
      "용인시",
      "의왕시",
      "이천시",
      "평택시",
      "하남시",
      "화성시",
      "양평군",
    ];

    if (southRegions.includes(cityRegion)) return "경기남부";
    if (northRegions.includes(cityRegion)) return "경기북부";
  }

  if (region1depthName === "강원") {
    const eastRegions = [
      "강릉시",
      "동해시",
      "삼척시",
      "속초시",
      "태백시",
      "고성군",
      "양양군",
    ];
    const westRegions = [
      "원주시",
      "춘천시",
      "양구군",
      "영월군",
      "인제군",
      "정선군",
      "철원군",
      "평창군",
      "홍천군",
      "화천군",
      "횡성군",
    ];

    if (eastRegions.includes(cityRegion)) return "영동";
    if (westRegions.includes(cityRegion)) return "영서";
  }

  return region1depthName;
};
```

- 위 함수에서 `return` 하는 값을 `cityRegion`에서 `region1depthName`으로 변경
- 기존에 `return` 하던 `cityRegion` 값은 예외 처리를 해준 지역이 아닌 지역(`서울시 서초구 서초동`)에서 `서초구`를 반환하게 됨
- 그렇기 때문에 예외 처리가 필요 없는 지역은 `서울시`, `인천시` 와 같이 `시`, `도` 지역명을 반환하도록 `return` 값 수정

## Result:

> `서울시 서초구 반포동` 기준

![mobile (1)](https://user-images.githubusercontent.com/70932170/235425430-0aad7c39-1a98-4e24-900b-b1c167dafd9b.png)

![mobile (2)](https://user-images.githubusercontent.com/70932170/235425442-a8d37dc4-a02e-4f5e-823d-f8c0cd9e8181.png)

> `경기도 용인시 수지구 죽전동` 기준

![mobile (3)](https://user-images.githubusercontent.com/70932170/235425524-e371479c-87f4-4368-af2b-6bb64863c1c6.png)

![mobile (4)](https://user-images.githubusercontent.com/70932170/235425531-30193361-e920-4315-8a11-60701f6d25f0.png)